### PR TITLE
allocation rewritten as product type

### DIFF
--- a/Verse/Arch.v
+++ b/Verse/Arch.v
@@ -37,19 +37,19 @@ Module Type ARCH.
   (** Generate code with assurance of well formedness **)
 
   
-  Parameter callConv : forall paramTypes localTypes, alloc var (paramTypes ++ localTypes).
+  Parameter callConv : forall paramTypes localTypes, allocation var (paramTypes ++ localTypes).
 
   (* Allocate with loopvar being allocated in a register by user *)
   Definition allocate loopvar paramTypes localVars localReg
                   (f      : func loopvar paramTypes localVars localReg)
-                  (lalloc : alloc var (loopvar :: localReg))
+                  (lalloc : allocation var (loopvar :: localReg))
     : Function var loopvar * FAllocation var paramTypes localVars localReg loopvar :=
 
     let calloc            := callConv paramTypes localVars in
     let (palloc, lvalloc) := alloc_split var paramTypes localVars calloc in
     let lv                := fst (fst (alloc_split var (loopvar :: nil) localReg lalloc)) in
     let lralloc           := snd (alloc_split var (loopvar :: nil) localReg lalloc) in
-    let f'                := fill' var lralloc (fill' var lvalloc (fill' var palloc (f var))) in
+    let f'                := fill var lralloc (fill var lvalloc (fill var palloc (f var))) in
     let fa                := {|
                                pa      := palloc;
                                lva     := lvalloc;
@@ -62,14 +62,14 @@ Module Type ARCH.
   (* Allocate with loopvar being allocated on stack by callConv *)
   Definition allocate' loopvar paramTypes localVars localReg
                   (f      : func loopvar paramTypes localVars localReg)
-                  (lalloc : alloc var localReg)
+                  (lalloc : allocation var localReg)
     : Function var loopvar * FAllocation var paramTypes localVars localReg loopvar :=
 
     let calloc            := callConv paramTypes (loopvar :: localVars) in
     let (palloc, ra)      := alloc_split var paramTypes (loopvar :: localVars) calloc in
     let (lva,lvalloc)     := alloc_split var (loopvar :: nil) localVars ra in
     let lv                := fst lva in
-    let f'                := fill' var lalloc (fill' var lvalloc (fill' var palloc (f var))) in
+    let f'                := fill var lalloc (fill var lvalloc (fill var palloc (f var))) in
     let fa                := {|
                                pa      := palloc;
                                lva     := lvalloc;

--- a/Verse/Function.v
+++ b/Verse/Function.v
@@ -20,10 +20,10 @@ Section Function.
 
   Record FAllocation (pl lv rv : list type) (t : type) := fallocation
                           {
-                            pa  : alloc v pl;
-                            lva : alloc v lv;
+                            pa  : allocation v pl;
+                            lva : allocation v lv;
                             loopvar : v t;
-                            rva : alloc v rv;
+                            rva : allocation v rv;
                           }.
 
   Definition fscoped (t : type) (pl lv rv : list type) (T : Type) := scoped v pl (scoped v lv (scoped v (t :: nil) (scoped v rv T))).

--- a/Verse/Function.v
+++ b/Verse/Function.v
@@ -1,48 +1,34 @@
 Require Import Types.Internal.
 Require Import Syntax.
 Require Import Language.
-Require Import Arch.
 Require Import String.
 Require Import Coq.Sets.Ensembles.
 Require Import List.
 Import ListNotations.
 
 
-Fixpoint listSet {A : Type} (l : list A) : Ensemble A :=
-  match l with
-  | [] => Empty_set _
-  | a :: lt => Ensembles.Add _ (listSet lt) a
-  end.
+Section Function.
 
-Module Type Function (arch : ARCH).
+  Variable v : varT.
   
-  Parameter name     : string.
+  Record Function t := function
+                         {
+                           setup   : block v;
+                           loop    : v t -> block v;
+                           cleanup : block v;
+                         }.
 
-  (** The variable type on which the function body is parametrized *)
-  Parameter fvar     : type -> Type.
+  Record FAllocation (pl lv rv : list type) (t : type) := fallocation
+                          {
+                            pa  : alloc v pl;
+                            lva : alloc v lv;
+                            loopvar : v t;
+                            rva : alloc v rv;
+                          }.
 
-  (** The ordered list of parameters of the function *)
-  Parameter param    : list {ty : type & fvar ty}.
+  Definition fscoped (t : type) (pl lv rv : list type) (T : Type) := scoped v pl (scoped v lv (scoped v (t :: nil) (scoped v rv T))).
 
-  (** Allocation onto _archvar_ from the local variables *)
-  Parameter localloc : list {fv : {ty : type & fvar ty} & (arch.var (projT1 fv))}.
-
-  Parameter loopvar  : {ty : type & fvar ty}.
-
-  Definition local := map (@projT1 {ty : type & fvar ty} _) localloc.
-
-  Parameter setup    : block fvar.
-  Parameter loop     : block fvar.
-  Parameter cleanup  : block fvar.
-
-  Definition usedvars := Ensembles.Add _
-                                       (Union _
-                                              (Union _ (bvars setup) (bvars loop))
-                                              (bvars cleanup))
-                                       loopvar.
-
-  (* ## Can be changed to use listSet and a disjoint union prop from the Ensemble library *)
-  Parameter allUsedListed : forall v : (sigT fvar), Ensembles.In _ usedvars v ->
-                                                    or (In v param) (In v local).
-  
 End Function.
+
+Definition func t pl lv rv := forall (v : varT),
+                              scoped v pl (scoped v lv (scoped v rv (Function v t))).

--- a/Verse/Syntax.v
+++ b/Verse/Syntax.v
@@ -231,6 +231,36 @@ Section Scoped.
     | ty :: lt => v ty -> scoped lt CODE
     end.
 
+  (* Some auxiliaries to work with scopes *)
+  
+  Fixpoint scopedApp {l : list type} {T T' : Type} : scoped l (T -> T') -> scoped l T -> scoped l T' :=
+    match l with
+    | nil     => fun scf => scf
+    | t :: lt => fun scf sc x => (scopedApp (scf x) (sc x))
+    end.
+
+  Fixpoint scopedConst (l : list type) {T : Type} (c : T) : scoped l T :=
+    match l return scoped l _ with
+    | nil     => c
+    | t :: lt => fun x => scopedConst lt c
+    end.
+
+  Fixpoint scopedAppConst {l : list type} {T T' : Type} (f : T -> T') : scoped l T -> scoped l T' :=
+    scopedApp (scopedConst l f).
+
+  Fixpoint merge_scope {l1 l2 : list type} {T : Type} : scoped l1 (scoped l2 T) -> scoped (l1 ++ l2) T := 
+    match l1 with
+    | nil      => fun x => x
+    | t :: l1t => fun x v => merge_scope (x v)
+    end.
+
+  Fixpoint split_scope {l1 l2 : list type} {T : Type} : scoped (l1 ++ l2) T -> scoped l1 (scoped l2 T) :=
+    match l1 with
+    | nil      => fun x => x
+    | t :: l1t => fun x v => split_scope (x v)
+    end.
+
+
   (** ** Allocation
 
     When generating code corresponding to the code fragment, we need a
@@ -239,18 +269,43 @@ Section Scoped.
 
    *)
 
-
   Inductive allocation : list type -> Type :=
   | EmptyAlloc : allocation []
   | Allocate  {ty : type}{l : list type} : v ty -> allocation l -> allocation (ty :: l)
   .
 
+  Fixpoint allocation_app {l1 l2 : list type} (a1 : allocation l1) (a2 : allocation l2) : allocation (l1 ++ l2) :=
+    match a1 with
+    | EmptyAlloc     => a2
+    | Allocate x a1t => Allocate x (allocation_app a1t a2)
+    end.
+
+  Fixpoint alloc (l : list type) : Type :=
+    match l with
+    | []      => unit
+    | t :: lt => v t * alloc lt
+    end.
+
+  Fixpoint alloc_split l1 l2 : alloc (l1 ++ l2) -> (alloc l1) * (alloc l2) :=
+    match l1 return alloc (l1 ++ l2) -> (alloc l1) * (alloc l2) with
+    | []      => fun x => pair tt x
+    | t :: lt => fun a : alloc ((t :: lt) ++ l2) =>
+                   (fun p : alloc lt * (alloc l2) =>
+                     pair (pair (fst a) (fst p)) (snd p))
+                   (alloc_split lt l2 (snd a))
+    end.
 
   (* This function fills in the variables from an allocation into a scoped code *)
   Fixpoint fill {CODE}{l : list type} (a : allocation l) : scoped l CODE -> CODE :=
     match a in allocation l0 return scoped l0 CODE -> CODE with
     | EmptyAlloc                   => fun x => x
     | @Allocate ty lrest v0 arest  => fun scfunc : v ty -> scoped lrest CODE => fill arest (scfunc v0)
+    end.
+
+  Fixpoint fill' {CODE} {l : list type} : alloc l -> scoped l CODE -> CODE :=
+    match l with
+    | []       => fun a x => x
+    | ty :: lt => fun a x => fill' (snd a) (x (fst a))
     end.
 
 End Scoped.

--- a/_CoqProject
+++ b/_CoqProject
@@ -10,3 +10,4 @@ Verse/Arch.v
 Verse/Language.v
 Verse/Types/Internal.v
 Verse/Syntax.v
+Verse/Function.v


### PR DESCRIPTION
I have moved a whole bunch of the auxiliaries I had written for 'scoped' into the syntax branch, in case they are required later. They are mostly natural commutation properties with list operations.