### PR TITLE
X86_64

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,7 @@
 -R src Verse
 src/Verse/Arch.v
 src/Verse/Arch/C.v
+src/Verse/Arch/X86_64.v
 src/Verse/Error.v
 src/Verse/Compile.v
 src/Verse/Language.v

--- a/src/Verse/Arch.v
+++ b/src/Verse/Arch.v
@@ -125,11 +125,11 @@ Module Type FRAME(A : ARCH).
 
   (** Allocate a local varaible on the stack *)
   Parameter stackAlloc : frameState ->
-                      forall k (ty : type k), A.machineVar ty * frameState + { ~ A.supportedType ty }.
+                      forall (ty : type direct), A.machineVar ty * frameState + { ~ A.supportedType ty }.
 
   (** Mark a register for use *)
   Parameter useRegister : frameState ->
-                          forall k (ty : type k)(r : A.register ty), option frameState.
+                          forall (ty : type direct)(r : A.register ty), option frameState.
 
 
 

--- a/src/Verse/Arch/C.v
+++ b/src/Verse/Arch/C.v
@@ -254,8 +254,8 @@ Module CFrame <: FRAME C.
        |}
     ).
 
-  Let newLocal state k ty :=
-    ( @onStack k ty (nLocals state),
+  Let newLocal state ty :=
+    ( @onStack direct ty (nLocals state),
       {| cFunctionName := cFunctionName state;
          iterateOn := iterateOn state;
          params := params state;
@@ -269,13 +269,13 @@ Module CFrame <: FRAME C.
     _ <- when C.typeCheck ty; {- @newParam state k ty -}.
 
 
-  Definition stackAlloc state k ty :=
-    _ <- when C.typeCheck ty; {- @newLocal state k ty -}.
+  Definition stackAlloc state ty :=
+    _ <- when C.typeCheck ty; {- @newLocal state ty -}.
 
 
   Let registerStrings state := List.map fst (registers state).
 
-  Definition useRegister state k ty (reg : creg ty ):=
+  Definition useRegister state ty (reg : creg ty ):=
       match reg with
       | cr _ nm =>
            if C.typeCheck ty then
@@ -286,7 +286,7 @@ Module CFrame <: FRAME C.
                       iterateOn := iterateOn state;
                       params := params state;
                       locals := locals state;
-                      registers := (nm , existT _ k ty) :: registers state
+                      registers := (nm , existT _ direct ty) :: registers state
                    |}
           else
             None

--- a/src/Verse/Arch/X86_64.v
+++ b/src/Verse/Arch/X86_64.v
@@ -160,7 +160,7 @@ Module X86 <: ARCH.
 
   Notation IsRegister reg arg := (isRegister reg arg = true).
 
-  Definition onStack {ty : type direct} {aK} (a : arg machineVar aK _ ty) :=
+  Definition onStack {k} {ty : type k} {aK} (a : arg machineVar aK _ ty) :=
     match a with
     | var (localStack _ _) | var (paramStack _ _) => true
     | _                  => false
@@ -187,7 +187,9 @@ Module X86 <: ARCH.
                                           /\ (isEndian xvar bigE a1 = true -> isMem a2 = false -> (ty = Word32 \/ ty = Word64) /\ onStack a2 = false)
                                           /\ (isEndian xvar bigE a1 = true -> isMem a2 = true -> isEndian xvar bigE a2 = true)
                                           /\ (isEndian xvar bigE a2 = true -> isMem a1 = true -> isEndian xvar bigE a1 = true)
-    | @moveTo _ _ _ _ ty a i v => (@isEndian xvar lval _ _ bigE (Ast.index a i) = true -> (ty = Word32 \/ ty = Word64) -> @onStack _ rval (var v) = false)
+    | @moveTo _ _ _ _ ty a i v => (@isEndian xvar lval _ _ bigE (Ast.index a i) = true ->
+                                   (ty = Word32 \/ ty = Word64) -> @onStack _ _ rval (var v) = false)
+    | CLOBBER v => @onStack _ _ rval (var v) = false
     | _ => False
     end.
 

--- a/src/Verse/Arch/X86_64.v
+++ b/src/Verse/Arch/X86_64.v
@@ -54,65 +54,11 @@ Definition xreg_eqb {k} (ty : type k) (x1 x2 : xreg ty) : bool :=
   | _, _               => false*)
   end.
 
-Lemma eq_dec_refl {T} (T_eq_dec : eq_dec T) (t : T) : {p : t = t | T_eq_dec t t = left p}.
-  pose (T_eq_dec t t).
-  change (T_eq_dec t t) with s.
-  destruct s.
-  destruct e. exists eq_refl; trivial.
-  destruct n; trivial.
-Qed.
-
-Lemma eq_dec_neq {T} (T_eq_dec : eq_dec T) (t1 t2 : T) : t1 <> t2 -> { p : t1 <> t2 | T_eq_dec t1 t2 = right p}.
-  intros.
-  pose (T_eq_dec t1 t2).
-  change (T_eq_dec t1 t2) with s.
-  destruct s;
-    [contradiction | ].
-  exists n; trivial.
-Qed.
-
-Ltac crush_eqb_eq :=
-  repeat match goal with
-         | [ |- _ <-> _ ] => constructor
-         | [ |- _ -> _  ] => try trivial; intros
-         | [ |- ?H _ _ = true ] => idtac H; autounfold
-         | |- context [?H ?x ?x] => destruct (eq_dec_refl H x) as [eq deceq]; rewrite deceq; trivial
-         end.
-
 Lemma xreg_eqb_eq{k} (ty : type k) (x1 x2 : xreg ty) : xreg_eqb x1 x2 = true <-> x1 = x2.
   Hint Unfold xreg_eqb.
   dependent destruction x1; dependent destruction x2.
-  (*
-  crush_eq_dec.
-  crush_eqb_eq.*)
-  destruct (xRegName_eq_dec x x0); subst.
-  constructor.
-  intros; trivial.
-  intros; unfold xreg_eqb.
-  destruct (eq_dec_refl xRegName_eq_dec x0).
-  rewrite e.
-  trivial.
-  constructor.
-  intros; unfold xreg_eqb in *.
-  destruct (xRegName_eq_dec x x0); easy.
-  inversion 1; contradiction.
-(*  constructor.
-  intros; unfold xreg_eqb in *; easy.
-  inversion 1; easy.
-  constructor.
-  intros; unfold xreg_eqb in *; easy.
-  inversion 1; easy.
-  destruct (xRegName_eq_dec x x1); subst.
-  constructor.
-  intros; trivial.
-  intros; unfold xreg_eqb.
-  destruct (eq_dec_refl xRegName_eq_dec x1).
-  rewrite e.
-  trivial.
-  constructor.
-  intros; unfold xreg_eqb in *.
-  destruct (xRegName_eq_dec x x1); easy.
-  inversion 1; easy.*)
+  crush_eq_dec;
+  crush_eqb_eq.
 Qed.
 
 Tactic Notation "fill_ineq" uconstr(B) := (refine B; omega).

--- a/src/Verse/Arch/X86_64.v
+++ b/src/Verse/Arch/X86_64.v
@@ -1,0 +1,559 @@
+Require Import Verse.
+Require Import Syntax.
+Require Import Language.
+Require Import Types.
+Require Import Types.Internal.
+Require Import Arch.
+Require Import Compile.
+Require Import Word.
+Require Import Error.
+Require Import PrettyPrint.
+Require Import DecFacts.
+Require Import Language.Ast.
+
+(* Require Import SeqFunction. *)
+
+Require Basics.
+Require Import Equality.
+Require Import ListDec.
+Require Import Omega.
+Require Import List.
+Import ListNotations.
+Require Import String.
+Require Import Ensembles.
+Require Vector.
+Import VectorNotations.
+Require Vectors.Fin.
+Require Import Bool.
+Set Implicit Arguments.
+
+Close Scope vector_scope.
+
+Inductive xRegName := reg_a | reg_b | reg_c | reg_d | reg_di | reg_si
+                      | reg_r8 | reg_r9 | reg_r10 | reg_r11 | reg_r12 | reg_r13 | reg_r14 | reg_r15.
+(*                      | reg_r (n : Fin.t 8) : xRegName.*)
+
+Hint Resolve Fin.eq_dec : decidable_prop.
+Lemma xRegName_eq_dec : eq_dec xRegName.
+  destruct A1; destruct A2; crush_eq_dec.
+Defined.
+
+Hint Resolve xRegName_eq_dec : decidable_prop.
+
+Inductive xreg : VariableT :=
+| xr (_ : xRegName) (k : kind) (ty : type k)  : xreg ty
+(*| xrH (_ : xRegName) : xreg Word8*)
+.
+
+(**** Consider moving xrL out too *)
+
+Definition xreg_eqb {k} (ty : type k) (x1 x2 : xreg ty) : bool :=
+  match x1, x2 with
+  | xr n1 _, xr n2 _ => if xRegName_eq_dec n1 n2 then true else false
+(*  | xrH r1, xrH r2     => if xRegName_eq_dec r1 r2 then true else false
+  | _, _               => false*)
+  end.
+
+Lemma eq_dec_refl {T} (T_eq_dec : eq_dec T) (t : T) : {p : t = t | T_eq_dec t t = left p}.
+  pose (T_eq_dec t t).
+  change (T_eq_dec t t) with s.
+  destruct s.
+  destruct e. exists eq_refl; trivial.
+  destruct n; trivial.
+Qed.
+
+Lemma eq_dec_neq {T} (T_eq_dec : eq_dec T) (t1 t2 : T) : t1 <> t2 -> { p : t1 <> t2 | T_eq_dec t1 t2 = right p}.
+  intros.
+  pose (T_eq_dec t1 t2).
+  change (T_eq_dec t1 t2) with s.
+  destruct s;
+    [contradiction | ].
+  exists n; trivial.
+Qed.
+
+Ltac crush_eqb_eq :=
+  repeat match goal with
+         | [ |- _ <-> _ ] => constructor
+         | [ |- _ -> _  ] => try trivial; intros
+         | [ |- ?H _ _ = true ] => idtac H; autounfold
+         | |- context [?H ?x ?x] => destruct (eq_dec_refl H x) as [eq deceq]; rewrite deceq; trivial
+         end.
+
+Lemma xreg_eqb_eq{k} (ty : type k) (x1 x2 : xreg ty) : xreg_eqb x1 x2 = true <-> x1 = x2.
+  Hint Unfold xreg_eqb.
+  dependent destruction x1; dependent destruction x2.
+  (*
+  crush_eq_dec.
+  crush_eqb_eq.*)
+  destruct (xRegName_eq_dec x x0); subst.
+  constructor.
+  intros; trivial.
+  intros; unfold xreg_eqb.
+  destruct (eq_dec_refl xRegName_eq_dec x0).
+  rewrite e.
+  trivial.
+  constructor.
+  intros; unfold xreg_eqb in *.
+  destruct (xRegName_eq_dec x x0); easy.
+  inversion 1; contradiction.
+(*  constructor.
+  intros; unfold xreg_eqb in *; easy.
+  inversion 1; easy.
+  constructor.
+  intros; unfold xreg_eqb in *; easy.
+  inversion 1; easy.
+  destruct (xRegName_eq_dec x x1); subst.
+  constructor.
+  intros; trivial.
+  intros; unfold xreg_eqb.
+  destruct (eq_dec_refl xRegName_eq_dec x1).
+  rewrite e.
+  trivial.
+  constructor.
+  intros; unfold xreg_eqb in *.
+  destruct (xRegName_eq_dec x x1); easy.
+  inversion 1; easy.*)
+Qed.
+
+Tactic Notation "fill_ineq" uconstr(B) := (refine B; omega).
+
+Notation al := (xr reg_a Word8).
+Notation ax := (xr reg_a Word16).
+Notation eax := (xr reg_a Word32).
+Notation rax := (xr reg_a Word64).
+
+Notation dl := (xr reg_d Word8).
+Notation dx := (xr reg_d Word16).
+Notation edx := (xr reg_d Word32).
+Notation rdx := (xr reg_d Word64).
+
+Inductive xvar : VariableT :=
+| inRegister     : forall k (ty : type k), xreg ty -> xvar ty
+| paramStack     : forall k (ty : type k), nat -> xvar ty
+| localStack     : forall k (ty : type k), nat -> xvar ty
+.
+
+Record xFrame := { xFunctionName : string;
+                   numParams      : nat;
+                   usedReg       : list xRegName;
+                   stackOffset   : nat }.
+
+Module X86 <: ARCH.
+
+  (** Name of the architecture family *)
+
+  Definition name : string := "X86-64".
+
+  (** The registers for this architecture *)
+
+  Definition register := xreg.
+
+  Definition machineVar := xvar.
+
+  Definition HostEndian := littleE.
+
+  Definition Word := Word64.
+
+  Definition embedRegister := inRegister.
+
+  Inductive typesSupported : forall k, Ensemble (type k) :=
+  | uint8             : typesSupported Word8
+  | uint16            : typesSupported Word16
+  | uint32            : typesSupported Word32
+  | uint64            : typesSupported Word64
+  | xarray {a n e ty} : typesSupported ty -> typesSupported (array a n e ty)
+  .
+
+  Fixpoint typeCheck {k}(ty : type k) : {typesSupported ty} + {~ typesSupported ty}.
+    refine (match ty with
+            | word 0 | word 1 | word 2 | word 3  => left _
+            | array a n e typ => match @typeCheck direct typ with
+                               | left proof      => left (xarray proof)
+                               | right disproof  => right _
+                               end
+            | _ => right _
+            end
+           ); repeat constructor; inversion 1; apply disproof; trivial.
+  Defined.
+
+  Definition supportedType := typesSupported.
+
+  Definition isConst {k} {ty : type k} {aK} (a : arg machineVar aK _ ty) :=
+    match a with
+    | const _ => true
+    | _       => false
+    end.
+
+  Definition isMem {ty : type direct} {aK} (a : arg machineVar aK _ ty) :=
+    match a with
+    | Ast.index _ _ => true
+    | _           => false
+    end.
+
+  Let simple_binop  : list (simop binary) :=
+    [plus; minus; bitOr; bitAnd; bitXor].
+
+  Definition isRegister {k} {ty : type k} (r : xreg ty) :
+    forall {k'} {ty' : type k'} {aK} (a : arg xvar aK _ ty'), bool.
+    intros.
+    destruct (kind_eq_dec k k'); [subst; destruct (ty_eq_dec ty ty'); [subst | ..] | ..].
+    destruct a. destruct x. exact (xreg_eqb x r).
+    all: exact false.
+  Defined.
+
+  Inductive isRegName (r : xRegName) :
+    forall {k} {ty : type k} {aK}, arg xvar aK _ ty -> Prop :=
+  | isRName : forall {k} (ty : type k) {aK}, isRegName r (@var _ aK _ _ (inRegister (xr r ty))).
+
+  Lemma isRegName_dec rn {k} {ty : type k} {aK} (a : arg xvar aK _ ty) : decidable (isRegName rn a).
+    destruct a as [ ? ? ? v | | ]; [ destruct v as [ ? ? r | | ] | .. ]; [ destruct r | ..];
+    crush_eq_dec.
+  Qed.
+
+  Hint Resolve isRegName_dec : decidable_prop.
+
+  Notation IsRegister reg arg := (isRegister reg arg = true).
+
+  Definition onStack {ty : type direct} {aK} (a : arg machineVar aK _ ty) :=
+    match a with
+    | var (localStack _ _) | var (paramStack _ _) => true
+    | _                  => false
+    end.
+
+  Definition supportedInst (i : instruction machineVar) :=
+    match i with
+    | assign (@update2 _ ty o a1 a2) =>  (List.In o simple_binop)
+                                         /\ (ty = Word64 -> isConst a2 = false)       (* immediates not 64-bit *)
+                                         /\ (isMem a1 = true -> isMem a2 = false)     (* both arguments cannot be memory *)
+    | assign (@update1 _ ty o a)     => True
+    | assign (@extassign3 _ ty exmul a1 a2 a3 a4) => (ty = Word64 -> isConst a4 = false)             (* immediates not 64-bit *)
+(*                                                     /\ (ty = Word8 -> IsRegister ah a1 ->
+                                                         IsRegister al a2 -> IsRegister al a3)       (* AH:AL <- AL * r/m 8 *)*)
+                                                     /\ (ty <> Word8 -> isRegName reg_d a1 ->
+                                                         isRegName reg_a a2 -> isRegName reg_a a3)   (* D:A   <- A  * r/m 16/32/64 *)
+    | assign (@extassign4 _ ty eucl a1 a2 a3 a4 a5) => (ty = Word64 -> isConst a5 = false)           (* immediates not 64-bit *)
+(*                                                       /\ (ty = Word8 -> IsRegister ah a1  -> IsRegister al a2
+                                                           -> IsRegister ah a3 -> IsRegister al a4)  (* (AH,AL) <- AH:AL / r/m 8 *) *)
+                                                       /\ (ty <> Word8 -> isRegName reg_d a1 -> isRegName reg_a a2 ->
+                                                           isRegName reg_d a3 -> isRegName reg_a a4) (* (D,A)   <- D:A   / r/m 16/32/64 *)
+    | assign (@assign2 _ ty nop a1 a2) => (ty = Word64 -> isConst a2 = true -> isMem a1 = false)
+                                          /\ (isConst a2 = true -> isMem a1 = true -> isEndian xvar bigE a1 = false)
+                                          /\ (isEndian xvar bigE a1 = true -> isMem a2 = false -> (ty = Word32 \/ ty = Word64) /\ onStack a2 = false)
+                                          /\ (isEndian xvar bigE a1 = true -> isMem a2 = true -> isEndian xvar bigE a2 = true)
+                                          /\ (isEndian xvar bigE a2 = true -> isMem a1 = true -> isEndian xvar bigE a1 = true)
+    | @moveTo _ _ _ _ ty a i v => (@isEndian xvar lval _ _ bigE (Ast.index a i) = true -> (ty = Word32 \/ ty = Word64) -> @onStack _ rval (var v) = false)
+    | _ => False
+    end.
+
+  Definition instCheck i : decidable (supportedInst i).
+    destruct i as [ a | x i | v ]; [ destruct a | .. ];
+      simpl; (try destruct o); try solve_decidable.
+  Defined.
+
+  Definition functionDescription := xFrame.
+
+End X86.
+
+Module XFrame <: FRAME X86.
+
+  Definition frameState := xFrame.
+
+  Definition emptyFrame s :=
+    {| xFunctionName := s;
+       numParams     := 0;
+       usedReg       := [];
+       stackOffset   := 0
+    |}.
+
+  Definition iterateFrame (s : string) (ty : type memory) :=
+    let state := {| xFunctionName := s;
+                    numParams     := 2;
+                    usedReg       := [reg_di; reg_si];
+                    stackOffset   := 0
+                 |} in
+    _ <- when X86.typeCheck ty; {- (inRegister (xr reg_di ty), inRegister (xr reg_si X86.Word), state) -}.
+
+  Definition CCregs : Vector.t xRegName 6 := [reg_di; reg_si; reg_d; reg_c; reg_r8; reg_r9]%vector.
+
+  Let newParam state k (ty : type k) :=
+    match lt_dec (numParams state) 6 with
+    | left plt => let r := nth_order CCregs plt in
+                  (inRegister (xr r ty),
+                   {| xFunctionName := xFunctionName state;
+                      numParams     := numParams state + 1;
+                      usedReg       := r :: usedReg state;
+                      stackOffset   := stackOffset state
+                   |})
+    | right _  => let ofst := 8 * (numParams state + 1 - 6 + 1) in
+                  (paramStack ty ofst,
+                   {| xFunctionName := xFunctionName state;
+                      numParams     := numParams state + 1;
+                      usedReg       := usedReg state;
+                      stackOffset   := stackOffset state
+                   |})
+    end.
+
+  Let newLocal state ty :=
+    let ofst := stackOffset state + @sizeOf direct ty in
+    (localStack ty ofst,
+    {| xFunctionName := xFunctionName state;
+       numParams     := numParams state;
+       usedReg       := usedReg state;
+       stackOffset   := ofst
+    |}).
+
+
+  Definition addParam state k ty :=
+    _ <- when X86.typeCheck ty; {- @newParam state k ty -}.
+
+  Definition stackAlloc state ty :=
+    _ <- when X86.typeCheck ty; {- @newLocal state ty -}.
+
+  Definition useRegister state (ty : type direct) (reg : xreg ty ):=
+    match reg with
+    | xr r ty =>
+      if X86.typeCheck ty then
+        if in_dec xRegName_eq_dec r (usedReg state)
+        then None
+        else Some
+               {| xFunctionName := xFunctionName state;
+                  numParams     := numParams state;
+                  usedReg       := r :: usedReg state;
+                  stackOffset   := stackOffset state
+               |}
+      else
+        None
+    end.
+
+  Definition description := @id xFrame.
+
+End XFrame.
+
+Definition orig_reg := [reg_a; reg_b; reg_c; reg_d]%list.
+Definition index_reg := [reg_di; reg_si]%list.
+Definition new_reg := [reg_r8; reg_r9; reg_r10; reg_r11; reg_r12; reg_r13; reg_r14; reg_r15]%list.
+
+Local Definition regName (r : xRegName) :=
+  match r with
+  | reg_a => text "a"
+  | reg_b => text "b"
+  | reg_c => text "c"
+  | reg_d => text "d"
+  | reg_di => text "di"
+  | reg_si => text "si"
+  | reg_r8 => text "r8"
+  | reg_r9 => text "r9"
+  | reg_r10 => text "r10"
+  | reg_r11 => text "r11"
+  | reg_r12 => text "r12"
+  | reg_r13 => text "r13"
+  | reg_r14 => text "r14"
+  | reg_r15 => text "r15"
+  end.
+
+Local Definition origRegWrite k (ty : type k) d := match ty with
+                                                   | Word8 => d <> text "l"
+                                                   | Word16 => d <> text "x"
+                                                   | Word32 => text "e" <> d <> text "x"
+                                                   | Word64
+                                                   | _      => text "r" <> d <> text "x"
+                                                   end.
+
+Local Definition indexRegWrite k (ty : type k) d := match ty with
+                                                    | Word8 => d <> text "l"
+                                                    | Word16 => d
+                                                    | Word32 => text "e" <> d
+                                                    | Word64
+                                                    | _      => text "r" <> d
+                                                    end.
+
+Local Definition newRegWrite k (ty : type k) d := match ty with
+                                                  | Word8 => d <> text "b"
+                                                  | Word16 => d <> text "w"
+                                                  | Word32 => d <> text "d"
+                                                  | Word64
+                                                  | _      => d
+                                                  end.
+
+
+Instance xRegPretty : forall k (ty : type k), PrettyPrint (xreg ty)
+  := { doc := fun x => text "%" <> let 'xr r ty := x in
+                                   let rd := regName r in
+                                   if in_dec xRegName_eq_dec r orig_reg
+                                   then origRegWrite ty rd
+                                   else if in_dec xRegName_eq_dec r index_reg
+                                        then indexRegWrite ty rd
+                                        else newRegWrite ty rd
+     }.
+
+Instance xMachineVar : forall k (ty : type k), PrettyPrint (xvar ty)
+  := { doc := fun x => match x with
+                       | inRegister r           => doc r
+                       | paramStack ty n        => decimal n <> paren (text "%ebp")
+                       | localStack ty n        => text "-" <> decimal n <> paren (text "%ebp")
+                       end
+     }.
+
+Local Definition xImm d := text "$" <> d.
+
+Local Fixpoint xArgdoc {aK}{k}(ty : type k ) (av : arg xvar aK k ty) :=
+  match av with
+  | var v       => doc v
+  | const c     => xImm (doc c)
+  | Ast.index v (exist _ n _) => decimal (sizeOf ty * n) <> paren (doc v)
+  end.
+
+Instance arg_pretty_print : forall aK k ty, PrettyPrint (arg xvar aK k ty)
+  := { doc := @xArgdoc _ _ ty }.
+
+
+Local Definition iSuffix {k} (ty : type k) := match ty with
+                                               | Word8 => text "b"
+                                               | Word16 => text "w"
+                                               | Word32 => text "l"
+                                               | Word64 => text "q"
+                                               | array _ _ _ _ => text "q"
+                                               | _      => text "badType"
+                                               end.
+
+Local Definition xOp {la ra} (o : op la ra) {k} (ty : type k) := match o with
+                                               | plus    => text "add"
+                                               | minus   => text "sub"
+                                               | mul     => text "imul"
+                                               | exmul   => text "mul"
+                                               | quot    => text "BadOp"
+                                               | rem     => text "BadOp"
+                                               | eucl    => text "div"
+                                               | bitOr   => text "or"
+                                               | bitAnd  => text "and"
+                                               | bitXor  => text "xor"
+                                               | bitComp => text "not"
+                                               | rotL n  => text "rol"
+                                               | rotR n  => text "ror"
+                                               | shiftL n => text "shl"
+                                               | shiftR n => text "shr"
+                                               | nop     => text "mov"
+                                                  end <> iSuffix ty.
+
+Local Definition biargs d1 d2 := commaSep [d1; d2].
+
+Local Definition mkInst i a := i <_> a.
+
+Local Definition bswap {k} (ty : type k) (x : xreg ty) :=
+  mkInst (text "bswap" <> iSuffix ty) (doc x).
+
+Local Definition move {ty : type direct} (la : larg _ direct ty) (ra : rarg _ direct ty) :=
+  let NOP := xOp nop ty in
+  match la with
+  | @Ast.index _ _ _ _ bigE _ _ _ => match ra, ty with
+                                      | var (inRegister x), Word32
+                                      | var (inRegister x), Word64 => vcat [ bswap x;
+                                                                               mkInst NOP (biargs (doc ra) (doc la)) ]
+                                      | @Ast.index _ _ _ _ bigE _ _ _, _ => mkInst NOP (biargs (doc ra) (doc la))
+                                      | _, _ => text "badInst"
+                                      end
+  | var (inRegister x) => match ra, ty with
+                          | @Ast.index _ _ _ _ bigE _ _ _, Word32
+                          | @Ast.index _ _ _ _ bigE _ _ _, Word64 => vcat [ mkInst NOP (biargs (doc ra) (doc la));
+                                                                             bswap x ]
+                          | _, _ => mkInst NOP (biargs (doc ra) (doc la))
+                          end
+  | _                  => mkInst NOP (biargs (doc ra) (doc la))
+  end.
+
+Local Definition store {ty : type direct} (la : larg _ direct ty) (ra : rarg _ direct ty) :=
+  vcat ([ move la ra ] ++
+                       match ra with
+                       | var (inRegister x) => match la with
+                                               | @Ast.index _ _ _ _ bigE _ _ _ => [bswap x]
+                                               | _ => []
+                                               end
+                       | _ => []
+                       end).
+
+Instance xAssignmentPrint : PrettyPrint (assignment xvar)
+  := { doc := fun assgn => match assgn with
+                           | @update2 _ ty op la ra => xOp op ty <_> biargs (doc ra) (doc la)
+                           | @update1 _ ty op la    => xOp op ty <_> match op with
+                                                                  | bitComp => doc la
+                                                                  | rotL n
+                                                                  | rotR n
+                                                                  | shiftL n
+                                                                  | shiftR n => biargs (xImm (decimal n)) (doc la)
+                                                                  | nop => biargs (doc la) (doc la)
+                                                                     end
+                           | @assign2 _ ty nop la ra => move la ra
+                           | _ => text "badInst"
+                           end
+     }.
+
+
+Global Instance instruction_C_print : PrettyPrint (instruction xvar)
+  := { doc := fun i => match i with
+                       | assign a => doc a
+                       | moveTo x i y => move (Ast.index x i) (var y)
+                       | CLOBBER a     => empty
+                       end
+     }.
+
+Module xCodeGen <: CODEGEN X86.
+
+  Import X86.
+
+  Definition emit (i : instruction xvar) : Doc + { not (supportedInst i) } :=
+    _ <- when instCheck i; {- doc i -}.
+
+  Definition sequenceInstructions ds := line <> vcat ds <> line.
+
+  Let preamble n := [  text ".text";
+                       text ".globl" <_> n;
+                       text ".type" <_> n <> text ", @function";
+                       empty;
+                       n <> text ":" ].
+
+  Let BP := text "%rbp".
+  Let SP := text "%rsp".
+  Let push r := mkInst (text "push" <> iSuffix Word) r.
+  Let pop r  := mkInst (text "pop" <> iSuffix Word) r.
+
+  Let setupBP := [ push BP;
+                   mkInst (xOp nop Word) (biargs SP BP) ].
+
+  Let allocStack n := if nat_eq_dec n 0 then [] else [mkInst (xOp minus Word) (biargs (xImm (decimal n)) SP)].
+  Let preserveRegs l := map (fun n => push (doc (xr n Word))) l.
+  Let restoreRegs l := map (fun n => pop (doc (xr n Word))) l.
+  Let clearStack n := if nat_eq_dec n 0 then [] else [mkInst (xOp plus Word) (biargs (xImm (decimal n)) SP)].
+
+  Let restoreBP := [mkInst (text "popq") BP].
+
+  Let ret := [text "ret"].
+
+  Let calleeSave := [reg_b; reg_r12; reg_r13; reg_r14; reg_r15].
+  Let toSave l := filter (fun r => if in_dec xRegName_eq_dec r calleeSave then true else false) l.
+  Let xComment s := text "#" <_> text s.
+
+  Definition makeFunction state body := let ofst := stackOffset state in
+                                        let name := text (xFunctionName state) in
+                                        let regs :=  toSave (usedReg state) in
+                                        vcat ((preamble name) ++
+                                                              [nest 4 (vcat ([empty; xComment "Stack setup"] ++
+                                                                             setupBP ++ allocStack ofst ++
+                                                                             [xComment "Callee saved registers"] ++
+                                                                             preserveRegs regs ++
+                                                                             [body;
+                                                                              xComment "Stack cleanup"] ++
+                                                                             clearStack ofst ++
+                                                                             [xComment "Restore registers"] ++
+                                                                             restoreRegs regs ++ restoreBP ++
+                                                                             ret))]).
+
+  Definition loopWrapper (msgTy : type memory) (v : machineVar msgTy) (n : machineVar Word) (d : Doc) : Doc :=
+    let label := text ".loopstart" in
+    let iterate := [ doc (mkInst (xOp plus Word) (biargs (xImm (decimal (sizeOf msgTy))) (doc v)));
+                     mkInst (text "dec" <> iSuffix Word) (doc n);
+                     mkInst (text "jnz") label ] in
+    vcat ([label <> text ":"] ++ [nest 4 d] ++ iterate).
+
+End xCodeGen.
+
+Module Compile := Compiler X86 XFrame xCodeGen.

--- a/src/Verse/Compile.v
+++ b/src/Verse/Compile.v
@@ -57,51 +57,52 @@ Module Compiler (A : ARCH) (F : FRAME A) (C : CODEGEN A).
 
     End CompileInstructions.
 
-    Section CompileAllocations.
+    Local Definition Allocation l := allocation A.machineVar l * F.frameState + { CompileError }.
 
-      Variable singleAlloc   :
-        F.frameState ->
-        forall k (ty : type k), A.machineVar ty * F.frameState + { ~ A.supportedType ty}.
-
-      Definition Allocation l := allocation A.machineVar l * F.frameState + { CompileError }.
-
-      Let liftTypeError
+    Local Definition liftTypeError
           {X : Type}
           {k : kind}
           {ty : type k}
           (action : X + { ~ A.supportedType ty}) : X + { CompileError }
-        := match action  with
-           | {- x -} => {- x -}
-           | error _ => error (UnsupportedType ty)
-           end.
+      := match action  with
+         | {- x -} => {- x -}
+         | error _ => error (UnsupportedType ty)
+         end.
 
-      Fixpoint generate (s0 : F.frameState)(l : list (some type)) : Allocation l :=
-        match l with
-        | []           => {- (emptyAllocation A.machineVar, s0) -}
-        | (existT _ _ ty :: rest)
-          => a1 <- liftTypeError (singleAlloc s0 ty);
-               let (v, s1) := a1
-               in a2 <- generate s1 rest;
-                    let (vs,s2) := a2
-                    in {- ((v,vs), s2) -}
-        end.
-
-      Definition iterateFrame name ty := liftTypeError (F.iterateFrame name ty).
-    End CompileAllocations.
+    Definition iterateFrame name ty := liftTypeError (F.iterateFrame name ty).
 
     (** Generate a frame with the given set of parameters or die trying *)
-    Definition params := generate F.addParam.
+    Fixpoint params s0 l : Allocation l :=
+      match l with
+      | []           => {- (emptyAllocation A.machineVar, s0) -}
+      | (existT _ _ ty :: rest)
+        => a1 <- liftTypeError (F.addParam s0 ty);
+             let (v, s1) := a1
+             in a2 <- params s1 rest;
+                  let (vs,s2) := a2
+                  in {- ((v,vs), s2) -}
+      end.
 
     (** Generate a frame with the given set of stack varaibles or die trying *)
-    Definition stacks := generate F.stackAlloc.
-
+    Fixpoint stacks s0 l : Allocation l :=
+      match l with
+      | []           => {- (emptyAllocation A.machineVar, s0) -}
+      | (existT _ memory ty :: _) => error (UnsupportedLocalArray ty)
+      | (existT _ direct ty :: rest)
+        => a1 <- liftTypeError (F.stackAlloc s0 ty);
+             let (v, s1) := a1
+             in a2 <- stacks s1 rest;
+                  let (vs,s2) := a2
+                  in {- ((v,vs), s2) -}
+      end.
 
     Fixpoint registers {l} : F.frameState ->
                              allocation A.register l -> Allocation l  :=
       match l with
       | []          => fun s0 _  => {- (emptyAllocation A.machineVar, s0) -}
-      | (existT _ k ty :: tys)
-        => fun s0 (rs : allocation A.register (existT _ k ty :: tys)) =>
+      | (existT _ memory ty :: _) => fun _ _ => error (UnsupportedLocalArray ty)
+      | (existT _ direct ty :: tys)
+        => fun s0 (rs : allocation A.register (existT _ _ ty :: tys)) =>
              let (r,rest) := rs in
              match F.useRegister s0 r with
              | Some s1 => restAlloc <- registers s1 rest;
@@ -151,25 +152,13 @@ Module Compiler (A : ARCH) (F : FRAME A) (C : CODEGEN A).
 
     Let wrap descr (code : Doc + {CompileError}) := C.makeFunction descr <$> code.
 
-
-    Let Fixpoint noArray lts :=
-      match lts with
-      | [] => {- [] -}
-      | existT _ direct ty :: ltst => cons (existT _ direct ty) <$> (noArray ltst)
-      | existT _ memory ty  :: _    => error (UnsupportedLocalArray ty)
-      end.
-
     Definition compile name pts lts rts regs f
       := let state := F.emptyFrame name
-         in lts' <- noArray lts;
-              rts' <- noArray rts;
-              result <- fillVars code state pts lts rts regs f;
+         in result <- fillVars code state pts lts rts regs f;
               let (descr, code) := result  in wrap descr (compileInstructions code).
 
     Definition compileIterator ty name pts lts rts regs iterF
       := S <- iterateFrame name ty;
-           lts' <- noArray lts;
-           rts' <- noArray rts;
            let (iterVars, state) := S in
            let (codeV, countV)  := iterVars
            in result <- @fillVars (iterator ty) state pts lts rts regs iterF;

--- a/src/Verse/DecFacts.v
+++ b/src/Verse/DecFacts.v
@@ -132,6 +132,7 @@ Ltac crush_eqb_eq :=
   repeat (match goal with
           | [ |- _ <-> _ ] => constructor
           | |- context [?H ?x ?x] => destruct (eq_dec_refl H x) as [eq deceq]; rewrite deceq; trivial
+          | H : ?a = ?a -> False |- _ => contradict H; trivial
           | H : ?a = ?b -> False |- context [?Heq_dec ?a ?b] => destruct (Heq_dec a b)
           | |- _ -> _ => intros
           | H : _ = _ |- _ => dependent destruction H

--- a/src/Verse/DecFacts.v
+++ b/src/Verse/DecFacts.v
@@ -57,6 +57,15 @@ Proof.
 tauto.
 Defined.
 
+Theorem iff_dec :
+  forall A B:Prop, A <-> B -> decidable A -> decidable B.
+Proof.
+  intros A B H AOR.
+  destruct AOR as [a | na].
+  left; apply H; easy.
+  right; intro; contradict na; apply H; easy.
+Defined.
+
 Notation eq_dec A := (forall A1 A2 : A, {A1 = A2} + {A1 <> A2}) (only parsing).
 Definition nat_eq_dec : eq_dec nat := NPeano.Nat.eq_dec.
 

--- a/src/Verse/Language/Pretty.v
+++ b/src/Verse/Language/Pretty.v
@@ -86,6 +86,15 @@ Notation "A ::=>*> N "    := (assign (update1 (rotR N)  (toLArg A))) (at level 7
 
 Notation "A ::== B"      := (assign (assign2 nop (toLArg A) (toRArg B))) (at level 70).
 Notation "'MOVE'  B 'TO'   A [- N -]"       := (moveTo A (exist _ (N%nat) _) B) (at level 200, A ident).
+
+Notation "( A : B ) ::= C [*] D" := (assign (extassign3 exmul
+                                                        (toLArg A) (toLArg B)
+                                                        (toRArg C) (toRArg D)))
+                                      (at level 70, A at level 99).
+Notation "( A , B ) ::= ( C : D ) [/] E" := (assign (extassign4 eucl
+                                                                   (toLArg A) (toLArg B)
+                                                                   (toRArg C) (toRArg D) (toRArg E)))
+                                              (at level 70, C at level 99, A at level 99).
 (**
 
 One another irritant in writing code is that the array indexing needs

--- a/src/Verse/Language/Pretty.v
+++ b/src/Verse/Language/Pretty.v
@@ -87,14 +87,16 @@ Notation "A ::=>*> N "    := (assign (update1 (rotR N)  (toLArg A))) (at level 7
 Notation "A ::== B"      := (assign (assign2 nop (toLArg A) (toRArg B))) (at level 70).
 Notation "'MOVE'  B 'TO'   A [- N -]"       := (moveTo A (exist _ (N%nat) _) B) (at level 200, A ident).
 
-Notation "( A : B ) ::= C [*] D" := (assign (extassign3 exmul
+Notation "'MULTIPLY' C 'AND' D 'INTO' ( A : B )" := (assign (extassign3 exmul
                                                         (toLArg A) (toLArg B)
                                                         (toRArg C) (toRArg D)))
-                                      (at level 70, A at level 99).
-Notation "( A , B ) ::= ( C : D ) [/] E" := (assign (extassign4 eucl
+                                       (at level 70, A at level 99).
+Notation "( 'QUOT' A , 'REM' B ) ::= ( C : D ) [/] E" := (assign (extassign4 eucl
                                                                    (toLArg A) (toLArg B)
                                                                    (toRArg C) (toRArg D) (toRArg E)))
-                                              (at level 70, C at level 99, A at level 99).
+                                              (at level 70, C at level 99).
+
+
 (**
 
 One another irritant in writing code is that the array indexing needs
@@ -311,7 +313,9 @@ operands of the programming fragment.
             X ::=>> 5;
             X ::= X [+] (A[- 2 -]);
             X ::= X [+] Ox "55";
-            Z ::= Z [+] vec_const
+            Z ::= Z [+] vec_const;
+            MULTIPLY X AND X INTO (X : X);
+            (QUOT X, REM X) ::= (X : X) [/] X
           ]%list.
 
   Defined.

--- a/src/Verse/Types/Internal.v
+++ b/src/Verse/Types/Internal.v
@@ -32,6 +32,13 @@ Inductive type       : kind -> Type :=
 | array              : align -> nat -> endian -> type direct -> type memory
 with endian : Type := bigE | littleE | hostE.
 
+Fixpoint sizeOf {k} (ty : type k) :=
+  match ty with
+  | word n         => 2 ^ n
+  | multiword m n  => 2 ^ m * 2 ^ n
+  | array _ n _ tw => n * sizeOf tw
+  end.
+
 (** Often we need to existentially quantify over types and other
     objects. This definition is just for better readability.
 *)


### PR DESCRIPTION
(A : B) ::= C [*] D
(A, B) ::= (C : D) [/] E

Are you sure we could not reuse the usual arithmetic notations for the operators? This effectively allowed us to overload pair.
I ask before trying to avoid repeating work :)